### PR TITLE
logic and tests for the Rook moves

### DIFF
--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -2,7 +2,15 @@ class Rook < Piece
 
     def is_valid?(new_x, new_y)
     	return false unless super
-    	(new_x == self.x_coordinate || new_y == self.y_coordinate)? true : false
+    	vertical_move(new_x) || horizontal_move(new_y)
+    end
+
+    def vertical_move(new_x)
+    	return new_x == self.x_coordinate
+    end
+
+    def horizontal_move(new_y)
+    	return new_y == self.y_coordinate
     end
 
 end

--- a/app/models/rook.rb
+++ b/app/models/rook.rb
@@ -1,3 +1,8 @@
 class Rook < Piece
 
+    def is_valid?(new_x, new_y)
+    	return false unless super
+    	(new_x == self.x_coordinate || new_y == self.y_coordinate)? true : false
+    end
+
 end

--- a/app/models/rook_spec.rb
+++ b/app/models/rook_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Rook, type: :model do
+
+	describe "is_valid? method" do
+		it "should not allow a diagonal move"
+			rook = FactoryBot.create(:rook)
+			rook.x_coordinate = 2
+			rook.y_coordinate = 2
+			is_valid = rook.is_valid?(2,2)
+			expect(is_valid).to eq false
+		end
+
+	end
+
+
+end

--- a/spec/factories/pieces.rb
+++ b/spec/factories/pieces.rb
@@ -19,4 +19,5 @@ FactoryBot.define do
   end
     factory :knight, class: Knight, parent: :piece do
     type "Knight"
+  end
 end

--- a/spec/factories/pieces.rb
+++ b/spec/factories/pieces.rb
@@ -14,4 +14,7 @@ FactoryBot.define do
   factory :queen, class: Queen, parent: :piece do
     type "Queen"
   end
+    factory :rook, class: Rook, parent: :piece do
+    type "Rook"
+  end
 end

--- a/spec/factories/pieces.rb
+++ b/spec/factories/pieces.rb
@@ -17,4 +17,6 @@ FactoryBot.define do
     factory :rook, class: Rook, parent: :piece do
     type "Rook"
   end
+    factory :knight, class: Knight, parent: :piece do
+    type "Knight"
 end

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Piece, type: :model do
 
       it "should allow a vertical move" do
           rook = FactoryBot.create(:rook)
-          is_valid = rook.is_valid?(4,2)
+          obstructing_piece = Piece.where(:game_id => rook.game_id, :x_coordinate => 4, :y_coordinate => 7)
+          obstructing_piece.delete_all
+          is_valid = rook.is_valid?(4,8)
           expect(is_valid).to eq true
       end
 

--- a/spec/models/rook_spec.rb
+++ b/spec/models/rook_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Piece, type: :model do
+  describe "is_valid? method" do
+    
+
+      it "should not allow a user not to move" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(4,4)
+          expect(is_valid).to eq false
+      end
+
+
+      it "should not allow a diagonal move" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(2,2)
+          expect(is_valid).to eq false
+      end
+
+      it "should not allow a move off the board on the x-axis" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(0,4)
+          expect(is_valid).to eq false
+      end
+
+      it "should not allow a move off the board on the y-axis" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(4,0)
+          expect(is_valid).to eq false
+      end
+
+      it "should allow a horizontal move" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(8,4)
+          expect(is_valid).to eq true
+      end
+
+      it "should allow a vertical move" do
+          rook = FactoryBot.create(:rook)
+          is_valid = rook.is_valid?(4,2)
+          expect(is_valid).to eq true
+      end
+
+
+  end
+end


### PR DESCRIPTION
Have finished the Rook is_valid code and tests? However I’ve found something odd that I’ve traced back to Piece level is_valid?

The vertical move test is failing when the y co-ordinate is 1 or 8. All other valid moves in the y-axis are fine. The horizontal test does not have this issue. 
My assumption was the code somewhere must be checking all values >= 8 and <=1 but that’s not the case that I can see.  Also when I tweaked the queen vertical move test co-ordinates I get the same failed vertical test for the queen.
I’ll have another look but any thoughts welcome!
Going forward will also refactor the tests to loop through all valid y-positions / x-positions to catch this kind of thing rather than using one fixed destination square for a move.


