### PR TITLE
Pawn Promotion working end to end

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,12 +49,13 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+gem 'bootstrap', '~> 4.0.0.beta3'
 gem 'rspec-rails', '~> 3.5'
 gem "factory_bot_rails"
 gem 'simple_form'
 gem 'devise'
 gem 'popper_js', '~> 1.12.3'
-gem 'bootstrap', '~> 4.0.0.beta3'
+
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-tether', '>= 1.3.3'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,3 +16,4 @@
 //= require popper
 //= require tether
 //= require bootstrap-sprockets
+//= require_tree .

--- a/app/assets/javascripts/board.js
+++ b/app/assets/javascripts/board.js
@@ -1,51 +1,9 @@
-/*
-
-// create html for the board of 8 x 8 sqaures
-  $(function buildTheBoard() {
-    var boardRef = $('.board');
-    var boardhtmlElement ="";
-
-    for (var row = 8; row >=1; row--) {
-      for (var column = 1; column <= 8; column ++) {
-
-        if (row % 2 == 0 && column % 2 == 0 ) { var colour = "black" };
-        if (row % 2 == 0 && column % 2 != 0 ) { var colour = "white" };
-        if (row % 2 != 0 && column % 2 == 0 ) { var colour = "white" };
-        if (row % 2 != 0 && column % 2 != 0 ) { var colour = "black" };
-
-        boardhtmlElement += '<div class="square ' + colour + ' pos' + row + column + '"' + ' data-id="' + row + column + '"></div>';
-      };
-    };
-    boardRef.html(boardhtmlElement);
-  });
-
-  
-
-  // boiler plate for detecting user event
-  $('body').click(function(e) {
-    var touched = $(e.target).data("id");
-    alert("you just clicked " + touched + ".");
-
-    });
-
-
-    // get the piece that has that x and y co-ordinate which matches
-    // how to search database from javascript!!!
-
-
-    // if none > show no piece here
-    // if piece matches > show piece selected
-    // when user clicks on destination > show piece from before now at that square
-    // and run piece update refresh the show screen.
-  */
-
 
   $( function() {
 
     $( ".piece" ).draggable({
 
        drag: function(event, ui){
-
        pieceToMove = $(event.target).data("piece"); 
       }
     }).css({'cursor': 'move', containment: 'parent', 'z-index': '5'})
@@ -56,22 +14,59 @@
         var targetSquare = $(event.target).data("id");
         var targetX = parseInt(targetSquare.toString().charAt(1));
         var targetY = parseInt(targetSquare.toString().charAt(0));
-
-        // return true/false on validity of move here...
-
         $.post("/pieces/" + pieceToMove, {
           _method: "PUT",
           piece: {
             x_coordinate: targetX, y_coordinate: targetY
           }
-        }).fail(function(response) {
-            alert('Error: ' + response.responseText);
+        }).success(function(data) {
+            if (Array.isArray(data)) {
+              userSelectsPiece(data, pieceToMove);
+            }
+
         });
       }
     })
 
   });
 
+  function userSelectsPiece(data, pieceToMove) {
+
+    var queenBtn = document.getElementById('queen');
+    var bishopBtn = document.getElementById('bishop');
+    var knightBtn = document.getElementById('knight');
+    var rookBtn = document.getElementById('rook');
+
+    var modalText = "You may promote your pawn to any of the following pieces, " + data + ".";
+
+    if (data.includes("Queen")) { queenBtn.hidden = false; } else { queenBtn.hidden = true; }
+    if (data.includes("Bishop")) { bishopBtn.hidden = false; } else { bishopBtn.hidden = true; }
+    if (data.includes("Knight")) { knightBtn.hidden = false; } else { knightBtn.hidden = true; }
+    if (data.includes("Rook")) { rookBtn.hidden = false; } else { rookBtn.hidden = true; }
+    $(".pieces-available").html(modalText);
+    $('#myModal').modal('show'); 
+
+    
+    queenBtn.onclick = function(e) {
+      applyPromote("Queen",pieceToMove)
+    };
+
+    bishopBtn.onclick = function(e) {
+      applyPromote("Bishop",pieceToMove)
+    };
+
+    knightBtn.onclick = function(e) {
+      applyPromote("Knight",pieceToMove)
+    };
+
+    rookBtn.onclick = function(e) {
+      applyPromote("Rook",pieceToMove)
+    };
+  }
+
+function applyPromote(targetPiece, pieceId) {
+  $.post('/pieces/promote', {id: pieceId, promotion: targetPiece});
+}
 
 
 

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -2,6 +2,18 @@
 
 }
 
+.btn-default {
+    padding: 10px 20px;
+    font-size: 21px;
+    font-weight: 700;
+    border-radius: 10px;
+    width:50%;
+
+}
+
+
+
+
 
 .board-title {
   text-align: center;
@@ -22,15 +34,16 @@
 }
 
 .piece {
+  padding-top: 5px;
   width: 100%;
   height: 100%;
   line-height: 100%;
   position: absolute;
-  color: blue;
+  color: black;
   text-align: center;
   display: table-cell;
   vertical-align: middle;
-  font-size: 400%;
+  font-size: 80px;
 }
 
 .white {
@@ -38,11 +51,14 @@
 }
 
 .black {
+  background-color: #D0D4A7;
+}
+.nothing {
   background-color: #1E1E1E;
 }
 
 .pos12 {
-  /* example - can use this reference to style individual board element, i.e. place piece image on board */
+  /* example - can use this reference to style individual board element */
 }
 
 .sidebar {

--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -1,1 +1,2 @@
 @import "bootstrap";
+

--- a/app/models/king.rb
+++ b/app/models/king.rb
@@ -1,8 +1,8 @@
 class King < Piece
 
   def is_valid?(new_x, new_y)
-    return false unless super 
-    return (x_coordinate - new_x).abs <=1 && (y_coordinate - new_y).abs <=1
+    false unless super 
+    (x_coordinate - new_x).abs <=1 && (y_coordinate - new_y).abs <=1
   end
 
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -17,4 +17,6 @@ class Pawn < Piece
     allowed_moves.push(allowed_moves[0]*2) if not moved
     return allowed_moves.include?(new_y - y_coordinate) && (new_x - x_coordinate).abs <= 1
   end
+
+
 end

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -18,5 +18,21 @@ class Pawn < Piece
     return allowed_moves.include?(new_y - y_coordinate) && (new_x - x_coordinate).abs <= 1
   end
 
+  def promotable?(new_y)
+    return true if type == "Pawn" && (white && new_y==8 || !white && new_y==1) 
+    return false
+  end
+
+  def promotable_pieces(new_x, new_y)
+    promotions_possible = ["Queen", "Bishop", "Knight", "Rook"]
+    promotions_available = []
+    promotions_possible.each do |piece|
+      self.type = piece
+      promotions_available << piece unless self.is_stalemate?
+    end
+    self.type = "Pawn"
+    return promotions_available
+  end
+
 
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -111,4 +111,25 @@ class Piece < ApplicationRecord
     return false if makes_check?(new_x, new_y)
     return true
   end
+
+  def is_stalemate?
+    return false
+  end 
+
+  def promotable?(new_y)
+    return true if type == "Pawn" && (white && new_y==8 || !white && new_y==1) 
+    return false
+  end
+
+  def promotable_pieces(new_x, new_y)
+    promotions_possible = ["Queen", "Bishop", "Knight", "Rook"]
+    promotions_available = []
+    promotions_possible.each do |piece|
+      self.type = piece
+      promotions_available << piece unless self.is_stalemate?
+    end
+    self.type = "Pawn"
+    return promotions_available
+  end
+
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -100,7 +100,7 @@ class Piece < ApplicationRecord
     old_x = x_coordinate
     old_y = y_coordinate
     update_attributes(x_coordinate: new_x, y_coordinate: new_y)
-    game.check?(white) ? check = true : check = false
+    game.check?(self.white) ? check = true : check = false
     update_attributes(x_coordinate: old_x, y_coordinate: old_y)
     check
   end
@@ -117,19 +117,9 @@ class Piece < ApplicationRecord
   end 
 
   def promotable?(new_y)
-    return true if type == "Pawn" && (white && new_y==8 || !white && new_y==1) 
     return false
   end
 
-  def promotable_pieces(new_x, new_y)
-    promotions_possible = ["Queen", "Bishop", "Knight", "Rook"]
-    promotions_available = []
-    promotions_possible.each do |piece|
-      self.type = piece
-      promotions_available << piece unless self.is_stalemate?
-    end
-    self.type = "Pawn"
-    return promotions_available
-  end
+
 
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,32 @@
 
 <%= javascript_include_tag "board" %>
 
+<!-- Modal -->
+  <div class="modal fade" id="myModal" role="dialog">
+    <div class="modal-dialog">
+    
+      <!-- Modal content-->
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal">&times;</button>
+          <h5 class="modal-title">Select Piece to Promote To</h5>
+        </div>
+        <div class="modal-body">
+          <div class="pieces-available"></div>
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" id="queen" data-dismiss="modal">queen ♕</button>
+          <button type="button" class="btn btn-default" id="bishop" data-dismiss="modal">bishop ♗</button>
+          <button type="button" class="btn btn-default" id="knight" data-dismiss="modal">knight ♘</button>
+          <button type="button" class="btn btn-default" id="rook" data-dismiss="modal">rook ♖</button>
+        </div>
+      </div>
+      
+    </div>
+  </div>
+
+
 <div class="col-11 offset 0.5 container">
   <div class="col-8 offset-2">
     <h1 class="board-title"><%= @game.name %></h1>
@@ -43,6 +69,4 @@
   </div>
 </div>
 
-<script>
 
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,18 @@
 	  <meta name="viewport" content="width=device-width, initial-scale=1">
 	  <title>jQuery UI Droppable - Default functionality</title>
 	  <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
-	  <link rel="stylesheet" href="/resources/demos/style.css">
-	  <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-	  <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <link rel="stylesheet" href="/resources/demos/style.css">
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 
   </head>
 
   <body>
+    <% if notice.present? %>
+      <p class="notice"><%= notice %></p>
+    <% end %>
+    <% if alert.present? %>
+      <p class="alert"><%= alert %></p>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'static_pages#index'
   resources :games, only: [:new, :create, :show, :update, :index]
-  resources :pieces, only: [:create, :show, :edit, :update]
+  resources :pieces, only: [:create, :show, :edit, :update] 
+
+  match 'pieces/promote' => 'pieces#promote_me', via: [:get, :post] 
+
 end

--- a/spec/models/king_spec.rb
+++ b/spec/models/king_spec.rb
@@ -14,15 +14,20 @@ RSpec.describe King, type: :model do
       expect(is_valid).to eq true
     end
     it "should check if king can move 1 space diagonally" do
-      mover = FactoryBot.create(:king)
-      is_valid = mover.is_valid?(3, 5)
+      game = FactoryBot.create(:game)
+      diag_moving_king = game.pieces.find_by(type: 'King', white: true)
+      diag_moving_king.x_coordinate = 4
+      diag_moving_king.y_coordinate = 4
+      is_valid = diag_moving_king.is_valid?(3, 5)
       expect(is_valid).to eq true
     end
     it "should check that king does not move into check" do
-      game = FactoryBot.create(:game)
-      king = game.pieces.find_by(type: 'King', white: true)
-      king.move!(4, 5)
-      is_valid = king.is_valid?(4, 6)
+      check_test_game = FactoryBot.create(:game)
+      check_king = check_test_game.pieces.find_by(type: 'King', white: true)
+      check_king.x_coordinate = 4
+      check_king.y_coordinate = 4
+      check_king.move!(4, 5)
+      is_valid = check_king.is_valid?(4, 6)
       expect(is_valid).to eq false
     end
   end

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -2,6 +2,39 @@ require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
 
+  describe "promotable? method" do
+    let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 7)}
+      it "should allow white pawn at eighth rank to be promoted" do
+        promotable = pawn.promotable?(8)
+        expect(promotable).to eq true
+      end  
+      it "should prevent white pawn below the eighth rank to be promoted" do
+        promotable = pawn.promotable?(7)
+        expect(promotable).to eq false
+      end
+
+    let(:blackpawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 7, white: false)}
+      it "should allow black pawn at eighth rank to be promoted" do
+        promotable = blackpawn.promotable?(1)
+        expect(promotable).to eq true
+      end 
+      it "should prevent pawn below the eighth rank to be promoted" do
+        promotable = blackpawn.promotable?(2)
+        expect(promotable).to eq false
+      end
+  end
+
+  describe "promotable_pieces method" do
+    let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 8)}
+      it "should confirm whether queening is possible" do
+        promotable = pawn.promotable_pieces(2,3)
+        expect(promotable).to eq ["Queen", "Bishop", "Knight", "Rook"]
+      end 
+  end
+
+
+
+
   describe "is_valid? method" do
     let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 2)}
 

--- a/spec/models/pawn_spec.rb
+++ b/spec/models/pawn_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
+
   describe "is_valid? method" do
     let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 2)}
 

--- a/spec/models/piece_spec.rb
+++ b/spec/models/piece_spec.rb
@@ -1,7 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Piece, type: :model do
-	describe "is_obstructed? method" do
+	 describe "promotable? method" do
+    let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 7)}
+      it "should allow white pawn at eighth rank to be promoted" do
+        promotable = pawn.promotable?(8)
+        expect(promotable).to eq true
+      end  
+      it "should prevent white pawn below the eighth rank to be promoted" do
+        promotable = pawn.promotable?(7)
+        expect(promotable).to eq false
+      end
+
+    let(:blackpawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 7, white: false)}
+      it "should allow black pawn at eighth rank to be promoted" do
+        promotable = blackpawn.promotable?(1)
+        expect(promotable).to eq true
+      end 
+      it "should prevent pawn below the eighth rank to be promoted" do
+        promotable = blackpawn.promotable?(2)
+        expect(promotable).to eq false
+      end
+  end
+
+  describe "promotable_pieces method" do
+    let(:pawn){FactoryBot.create(:pawn, x_coordinate: 3, y_coordinate: 8)}
+      it "should confirm whether queening is possible" do
+        promotable = pawn.promotable_pieces(2,3)
+        expect(promotable).to eq ["Queen", "Bishop", "Knight", "Rook"]
+      end 
+  end
+
+
+  describe "is_obstructed? method" do
     it "should check if the move is a straight line" do
     	user = FactoryBot.create(:user)
     	game = FactoryBot.create(:game, user_id: user.id)


### PR DESCRIPTION
Okay that took a bit more than expected. As briefly as I can.....

In pieces controller, if the move is valid we run the promotable? on the pawn object. If that returns true, promotable_pieces on the pieces controller returns an array of promotions_available. It does this after checking whether each of the Queen, Bishop, Knight and Rook pieces can replace the Pawn without causing stalemate.

Next we return the array to javascript and verify whether we have an array; if so we show modal on the games view with buttons for ONLY each piece in the array, i.e. if a Queen would cause stalemate, you don't get that as a promotion upgrade.

User can then select which piece to promote their Pawn to. After this we run a JSON update of the piece using the promote_me method on piece controller and that handles the update to database and does a redirect to give us the pawn now appearing as a Queen/Bishop etc.
Learned a lot!